### PR TITLE
[PLAY-108]: Expose types of Network Graph for consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "/network-graph",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "module": "dist/index.modern.js",
   "source": "src/index.tsx",
   "engines": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,21 @@ import { Graph } from './graph'
 import { Zoom, ZoomChildrenProps } from './zoom'
 import { BaseNode, BaseLink, NetworkGraphProps } from './types'
 
+export {
+  NodeId,
+  BaseNode,
+  BaseLink,
+  Data,
+  NodeComponentProps,
+  DetailsComponentProps,
+  LinkComponentProps,
+  GraphProps,
+  NetworkGraphProps,
+  Simulation,
+  SelectedNode,
+  SelectedLink,
+} from './types'
+
 type GraphWithZoomProps<
   Node extends BaseNode = BaseNode,
   Link extends BaseLink<Node> = BaseLink<Node>,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "module": "esnext",
     "target": "ES6",
     "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2016.Array.Include", "esnext"],
     "types": ["node", "jest"],
     "moduleResolution": "node",
     "sourceMap": true,
-    "declaration": false,
+    "declaration": true,
     "strict": false,
     "noImplicitAny": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Made main types and interfaces importable from package.

<img width="1728" alt="Screenshot 2023-06-15 at 00 31 23" src="https://github.com/dechegaray/react-graph-network/assets/33761040/37b71653-5eb6-4558-848c-ce69d917c868">
