### PR TITLE
[PLAY-107]: The zoom control is made optional in the network-graph

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,12 @@ export const NetworkGraph = <Node extends BaseNode = BaseNode, Link extends Base
   props: NetworkGraphProps<Node, Link>,
 ) => {
   return (
-    <Zoom className='network-graph' data-testid='network-graph'>
+    <Zoom
+      className='network-graph'
+      data-testid='network-graph'
+      enableZoomButtons={props?.enableZoomButtons}
+      enableMouseWheelZoom={props?.enableMouseWheelZoom}
+    >
       {({ zoom, height, width }) => {
         return <GraphWithZoom<Node, Link> {...props} zoom={zoom} width={width} height={height} />
       }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface GraphProps<Node extends BaseNode = BaseNode, Link extends BaseL
   id?: string
   pullIn?: boolean
   enableDrag?: boolean
+  enableZoomButtons?: boolean
+  enableMouseWheelZoom?: boolean
   nodeDistance?: number
   hoverOpacity?: number
   selectNode?(node: Node): void

--- a/src/zoom.tsx
+++ b/src/zoom.tsx
@@ -20,9 +20,20 @@ export interface ZoomChildrenProps {
 interface ZoomProps {
   children(props: ZoomChildrenProps): ReactElement
   className: string
+  enableZoomButtons: boolean
+  enableMouseWheelZoom: boolean
 }
 
-export const Zoom = ({ children, ...rest }: ZoomProps) => {
+export const Zoom = ({ children, enableZoomButtons = true, enableMouseWheelZoom = true, ...rest }: ZoomProps) => {
+  const handleMouseWheel = (event: React.WheelEvent<HTMLDivElement>, zoom: ZoomState) => {
+    if (!enableMouseWheelZoom) return
+    if (event.deltaY > 0) {
+      zoom.scale({ scaleX: 1.25, scaleY: 1.25 })
+    } else {
+      zoom.scale({ scaleX: 0.75, scaleY: 0.75 })
+    }
+  }
+
   return (
     <ParentSize {...rest}>
       {({ width, height }) => {
@@ -51,10 +62,10 @@ export const Zoom = ({ children, ...rest }: ZoomProps) => {
             initialTransformMatrix={initialTransform}
           >
             {(zoom) => (
-              <React.Fragment>
+              <div onWheel={(event) => handleMouseWheel(event, zoom)}>
                 {children({ zoom, height, width })}
-                <NavigationControls zoom={zoom} />
-              </React.Fragment>
+                {enableZoomButtons && <NavigationControls zoom={zoom} />}
+              </div>
             )}
           </VXZoom>
         )


### PR DESCRIPTION
- Added a prop that can disable the Zoom completely from the end result.
- Added a prop that allow users to disable/enable zooming in/out with the wheel of the mouse.